### PR TITLE
function is_author now checks author state only

### DIFF
--- a/subscribe-to-comments-reloaded/subscribe-to-comments-reloaded.php
+++ b/subscribe-to-comments-reloaded/subscribe-to-comments-reloaded.php
@@ -726,7 +726,7 @@ class wp_subscribe_reloaded {
 	public function is_author( $_post_author ) {
 		global $current_user;
 
-		return ! empty( $current_user ) && ( ( $_post_author == $current_user->ID ) || current_user_can( 'manage_options' ) );
+		return ! empty( $current_user ) && ( ( $_post_author == $current_user->ID ) );
 	}
 	// end is_author
 


### PR DESCRIPTION
stripped

 || current_user_can( 'manage_options' )

from

public function is_author

as it prevents Admins getting the subscription checkbox shown. Admins are still able to manage subscriptions of other authors through subscribe-to-commments admin panel.