### PR TITLE
Update sctr email address when user updates account

### DIFF
--- a/subscribe-to-comments-reloaded/wp_subscribe_reloaded.php
+++ b/subscribe-to-comments-reloaded/wp_subscribe_reloaded.php
@@ -30,6 +30,8 @@ namespace stcr {
 				add_action( 'comment_post', array( $this, 'new_comment_posted' ), 12, 2 );
 				// Add hook for the subscribe_reloaded_purge, define on the constructure so that the hook is read on time.
 				add_action('_cron_subscribe_reloaded_purge', array($this, 'subscribe_reloaded_purge'), 10 );
+				// Update email when a subscribed user updates their email address
+				add_action( 'profile_update', array ($this, 'update_subscribed_user_email' ), 10, 2 );
 				
 				// Load Text Domain
 				add_action( 'plugins_loaded', array( $this, 'subscribe_reloaded_load_plugin_textdomain' ) );
@@ -716,6 +718,17 @@ namespace stcr {
 			}
 			// end update_subscription_status
 
+			/**
+			* Wrapper for update_subscription_email used to update email of subscribed user on profile change
+			*/
+			public function update_subscribed_user_email( $user_id, $old_user_data ) {
+
+				$new_user_data = get_userdata( $user_id );
+				$this->update_subscription_email( 0, $old_user_data->user_email, $new_user_data->user_email );
+
+			}
+			// end update_subscribed_user_email
+			
 			/**
 			 * Updates the email address of an existing subscription
 			 */


### PR DESCRIPTION
The scenario is this:
1) A user has an account on a site.
2) The user makes subscribes to a comment
3) The user updates their email address in their account profile

At the moment, I think the user's email address is not updated in the subscribe_reloaded_subscribers table, which means that all the notifications are now sent to the wrong email address.

This change uses the 'profile update' hook to update the email address in the subscribe_reloaded_subscribers table.

Tested and seems to work ok.