### PR TITLE
Fix for option value being overwritten

### DIFF
--- a/src/options/stcr_comment_form.php
+++ b/src/options/stcr_comment_form.php
@@ -8,17 +8,18 @@ if ( ! function_exists( 'is_admin' ) || ! is_admin() ) {
 }
 
 $options = array(
-    "show_subscription_box"         => "yesno",
-    "checked_by_default"            => "yesno",
-    "checked_by_default_value"      => "integer",
-    "enable_advanced_subscriptions" => "yesno",
-    "default_subscription_type"     => "integer",
-    "checkbox_inline_style"         => "text-html",
-    "checkbox_html"                 => "text-html",
-    "checkbox_label"                => "text-html",
-    "subscribed_label"              => "text-html",
-    "subscribed_waiting_label"      => "text-html",
-    "author_label"                  => "text-html"
+    "show_subscription_box"                 => "yesno",
+    "checked_by_default"                    => "yesno",
+    "checked_by_default_value"              => "integer",
+    "enable_advanced_subscriptions"         => "yesno",
+    "enable_advanced_subscriptions_value"   => "integer",
+    "default_subscription_type"             => "integer",
+    "checkbox_inline_style"                 => "text-html",
+    "checkbox_html"                         => "text-html",
+    "checkbox_label"                        => "text-html",
+    "subscribed_label"                      => "text-html",
+    "subscribed_waiting_label"              => "text-html",
+    "author_label"                          => "text-html"
 );
 
 // Update options
@@ -174,7 +175,7 @@ if ( isset( $_POST['options'] ) ) {
                     </div>
                     <?php
                 else :
-                    echo "<input type='hidden' name='options[checked_by_default_value]' value = '0'>";
+                    echo "<input type='hidden' name='options[enable_advanced_subscriptions_value]' value = '0'>";
                 endif; ?>
 
                 <div class="form-group row">

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -336,6 +336,7 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
             add_option( 'subscribe_reloaded_show_subscription_box', 'yes', '', 'yes' );
             add_option( 'subscribe_reloaded_checked_by_default', 'no', '', 'yes' );
             add_option( 'subscribe_reloaded_enable_advanced_subscriptions', 'no', '', 'yes' );
+            add_option( 'subscribe_reloaded_enable_advanced_subscriptions_value', '0', '', 'yes' );
             add_option( 'subscribe_reloaded_default_subscription_type', '2', '', 'yes' );
             add_option( 'subscribe_reloaded_checked_by_default_value', '0', '', 'yes' );
             add_option( 'subscribe_reloaded_checkbox_inline_style', 'width:30px', '', 'yes' );


### PR DESCRIPTION
Right now you cannot change the option "Default checkbox value" whenever "Advanced subscription" is set to "no" because an input field with the same name was overwriting it. I think this fixes that.