### PR TITLE
Add missing dependecies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,5 +12,8 @@
     "config": {
         "vendor-dir": "src/vendor",
         "preferred-install": "dist"
+    },
+    "require-dev": {
+        "phing/phing": "2.*"
     }
 }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/stcr/subscribe-to-comments-reloaded#readme",
   "devDependencies": {
     "babel-eslint": "^8.2.2",
+    "bower": "^1.8.12",
     "eslint-plugin-compat": "^2.2.0",
     "gulp": "3.9.1",
     "gulp-eslint": "^4.0.2",


### PR DESCRIPTION
* Add missing dependecies to the packages configuration files.
With these two missing configuration you can use **phing** and
**bower** to copy the needed files. Additional contributors
will have no troubles setting up the dev environment.

After you do `npm install` & `composer install` you can now install the bower dependencies with `./node_modules/bower/bin/bower install`

Just run the `phing` command to copy the **bower components** to the vendor directory.

`src/vendor/phing/phing/bin/phing`