### PR TITLE
Strip HTML tags from title — Fix #678

### DIFF
--- a/src/options/stcr_manage_subscriptions.php
+++ b/src/options/stcr_manage_subscriptions.php
@@ -237,7 +237,7 @@ if ( is_readable( trailingslashit( dirname( STCR_PLUGIN_FILE ) ) . 'options/pane
 
                                     foreach ( $subscriptions as $a_subscription ) {
                                         //$wp_subscribe_reloaded->stcr->utils->stcr_logger( print_r($a_subscription, true) );
-                                        $title     = get_the_title( $a_subscription->post_id );
+                                        $title     = wp_strip_all_tags( get_the_title( $a_subscription->post_id ) );
                                         $title     = ( strlen( $title ) > 35 ) ? substr( $title, 0, 35 ) . '..' : $title;
                                         if( $wp_locale->text_direction == 'rtl' )
                                         {


### PR DESCRIPTION
This PR fixes #678, where the admin interface of StCr does function at all due to HTML being used in a post title.