### PR TITLE
Enqueue CSS and JS

### DIFF
--- a/src/options/index.php
+++ b/src/options/index.php
@@ -9,8 +9,6 @@ global $wp_locale;
 
 ?>
 
-<link href="<?php echo esc_url( plugins_url( '/vendor/bootstrap/dist/css/bootstrap.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-<link href="<?php echo esc_url( plugins_url( '/vendor/Font-Awesome/web-fonts-with-css/css/fontawesome-all.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
 <style type="text/css">
     #wpcontent {
         background: #f1f1f1 !important;
@@ -22,5 +20,3 @@ global $wp_locale;
     }
     .navbar a { font-size: 1em !important; font-weight: 600; color: #464646 !important;}
 </style>
-
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/bootstrap/dist/js/bootstrap.bundle.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>

--- a/src/options/options_template.php
+++ b/src/options/options_template.php
@@ -58,6 +58,13 @@ if ( isset( $_POST['options'] ) ) {
 
     $faulty_fields     = array();
     $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+    $subscribe_options = array_map(
+        array(
+            'stcr\stcr_utils',
+            'sanitize_options'
+        ),
+        $subscribe_options
+    );
     foreach ( $subscribe_options as $option => $value )
     {
         if ( ! $wp_subscribe_reloaded->stcr->utils->stcr_update_menu_options( $option, $value, $options[$option] ) )

--- a/src/options/options_template.php
+++ b/src/options/options_template.php
@@ -79,8 +79,6 @@ if ( isset( $_POST['options'] ) ) {
 wp_print_scripts( 'quicktags' );
 
 ?>
-    <link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-
     <div class="container-fluid">
         <div class="mt-3"></div>
         <div class="row">
@@ -118,7 +116,6 @@ wp_print_scripts( 'quicktags' );
 
         </div>
     </div>
-    <script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 //global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/panel1-business-logic.php
+++ b/src/options/panel1-business-logic.php
@@ -136,6 +136,7 @@ switch ( $action ) {
 
             $post_list = $email_list = array();
             $subscription_lists = wp_unslash( $_POST['subscriptions_list'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+            $subscription_lists = array_map( 'wp_kses_post', $subscription_lists );
             foreach ( $subscription_lists as $a_subscription ) {
                 list( $a_post, $a_email ) = explode( ',', $a_subscription );
                 if ( ! in_array( $a_post, $post_list ) ) {

--- a/src/options/stcr_comment_form.php
+++ b/src/options/stcr_comment_form.php
@@ -38,6 +38,13 @@ if ( isset( $_POST['options'] ) ) {
 
 	$faulty_fields     = array();
     $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+    $subscribe_options = array_map(
+        array(
+            'stcr\stcr_utils',
+            'sanitize_options'
+        ),
+        $subscribe_options
+    );
     foreach ( $subscribe_options as $option => $value )
     {
 

--- a/src/options/stcr_comment_form.php
+++ b/src/options/stcr_comment_form.php
@@ -58,8 +58,6 @@ if ( isset( $_POST['options'] ) ) {
 	echo '</p></div>';
 }
 ?>
-<link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-
 <div class="container-fluid">
     <div class="mt-3"></div>
     <div class="row">
@@ -375,7 +373,6 @@ if ( isset( $_POST['options'] ) ) {
     </div>
 </div>
 
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_manage_subscriptions.php
+++ b/src/options/stcr_manage_subscriptions.php
@@ -32,13 +32,6 @@ if ( is_readable( trailingslashit( dirname( STCR_PLUGIN_FILE ) ) . 'options/pane
 }
 
 ?>
-<style type="text/css">
-
-</style>
-
-<link href="<?php echo esc_url( plugins_url( '/vendor/datatables/media/css/jquery.dataTables.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-<link href="<?php echo esc_url( plugins_url( '/vendor/datatables/media/css/dataTables.bootstrap4.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-<link href="<?php echo esc_url( plugins_url( '/vendor/datatables.net-responsive-bs4/css/responsive.bootstrap4.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
 
 <div class="container-fluid">
 
@@ -343,11 +336,6 @@ if ( is_readable( trailingslashit( dirname( STCR_PLUGIN_FILE ) ) . 'options/pane
         </div>
     </div>
 </div>
-
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/datatables/media/js/jquery.dataTables.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/datatables/media/js/dataTables.bootstrap4.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/datatables.net-responsive/js/dataTables.responsive.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
-<script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/datatables.net-responsive-bs4/js/responsive.bootstrap4.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 
 <?php
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_management_page.php
+++ b/src/options/stcr_management_page.php
@@ -76,8 +76,6 @@ if ( isset( $_POST['options'] ) ) {
 wp_print_scripts( 'quicktags' );
 
 ?>
-    <link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-
     <div class="container-fluid">
         <div class="mt-3"></div>
         <div class="row">
@@ -440,7 +438,6 @@ wp_print_scripts( 'quicktags' );
         </div>
     </div>
 
-    <script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_management_page.php
+++ b/src/options/stcr_management_page.php
@@ -44,6 +44,13 @@ if ( isset( $_POST['options'] ) ) {
 
     $faulty_fields = array();
     $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+    $subscribe_options = array_map(
+        array(
+            'stcr\stcr_utils',
+            'sanitize_options'
+        ),
+        $subscribe_options
+    );
     foreach ( $subscribe_options as $option => $value )
     {
         if ( ! $wp_subscribe_reloaded->stcr->utils->stcr_update_menu_options( $option, $value, $options[$option] ) )

--- a/src/options/stcr_notifications.php
+++ b/src/options/stcr_notifications.php
@@ -74,8 +74,6 @@ if ( isset( $_POST['options'] ) ) {
 wp_print_scripts( 'quicktags' );
 
 ?>
-    <link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-
     <div class="container-fluid">
         <div class="mt-3"></div>
         <div class="row">
@@ -372,7 +370,6 @@ wp_print_scripts( 'quicktags' );
         </div>
     </div>
 
-    <script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 //global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_notifications.php
+++ b/src/options/stcr_notifications.php
@@ -38,6 +38,13 @@ if ( isset( $_POST['options'] ) ) {
 
     $faulty_fields = array();
     $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+    $subscribe_options = array_map(
+        array(
+            'stcr\stcr_utils',
+            'sanitize_options'
+        ),
+        $subscribe_options
+    );
     foreach ( $subscribe_options as $option => $value )
     {
 

--- a/src/options/stcr_options.php
+++ b/src/options/stcr_options.php
@@ -95,6 +95,13 @@ if ( array_key_exists( "generate_key", $_POST ) ) {
 
     $faulty_fields     = array();
     $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+    $subscribe_options = array_map(
+        array(
+            'stcr\stcr_utils',
+            'sanitize_options'
+        ),
+        $subscribe_options
+    );
     foreach ( $subscribe_options as $option => $value )
     {
         if ( ! $wp_subscribe_reloaded->stcr->utils->stcr_update_menu_options( $option, $value, $options[$option] ) )

--- a/src/options/stcr_options.php
+++ b/src/options/stcr_options.php
@@ -116,8 +116,6 @@ if ( array_key_exists( "generate_key", $_POST ) ) {
 wp_print_scripts( 'quicktags' );
 
 ?>
-    <link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
-
     <div class="container-fluid">
         <div class="mt-3"></div>
         <div class="row">
@@ -812,7 +810,6 @@ wp_print_scripts( 'quicktags' );
 
         </div>
     </div>
-    <script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 //global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_system.php
+++ b/src/options/stcr_system.php
@@ -430,7 +430,12 @@ else {
 
                         // Get the SSL status.
                         if ( ini_get( 'allow_url_fopen' ) ) {
-                            $tlsCheck = file_get_contents( 'https://www.howsmyssl.com/a/check' );
+                            $tlsRemote    = wp_remote_get( 'https://www.howsmyssl.com/a/check' );
+                            $responseCode = wp_remote_retrieve_response_code( $tlsRemote );
+
+                            if ( 200 === $responseCode ) {
+                                $tlsCheck = wp_remote_retrieve_body( $tlsRemote );
+                            }
                         }
 
                         if ( false !== $tlsCheck )

--- a/src/options/stcr_system.php
+++ b/src/options/stcr_system.php
@@ -139,7 +139,6 @@ else {
     }
 }
 ?>
-    <link href="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) ); ?>" rel="stylesheet"/>
     <style type="text/css">
         .system-error {
             color: #dc3545;
@@ -777,7 +776,6 @@ else {
 
         </div>
     </div>
-    <script type="text/javascript" src="<?php echo esc_url( plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ) ); ?>"></script>
 <?php
 //global $wp_subscribe_reloaded;
 // Tell WP that we are going to use a resource.

--- a/src/options/stcr_system.php
+++ b/src/options/stcr_system.php
@@ -103,6 +103,13 @@ else {
 
         $faulty_fields     = array();
         $subscribe_options = wp_unslash( $_POST['options'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+        $subscribe_options = array_map(
+            array(
+                'stcr\stcr_utils',
+                'sanitize_options'
+            ),
+            $subscribe_options
+        );
         foreach ( $subscribe_options as $option => $value )
         {
             if ( ! $wp_subscribe_reloaded->stcr->utils->stcr_update_menu_options( $option, $value, $options[$option] ) )

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -563,7 +563,13 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
             $stcr_admin_css = plugins_url( '/includes/css/stcr-admin-style.css', STCR_PLUGIN_FILE );
 
             // register scripts
-            wp_register_script('stcr-admin-js', $stcr_admin_js, array( 'jquery' ) );
+            wp_register_script( 'stcr-admin-js', $stcr_admin_js, array( 'jquery' ) );
+            wp_register_script( 'bootstrap', plugins_url( '/vendor/bootstrap/dist/js/bootstrap.bundle.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
+            wp_register_script( 'webui-popover', plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
+            wp_register_script( 'dataTables', plugins_url( '/vendor/datatables/media/js/jquery.dataTables.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
+            wp_register_script( 'dataTables-bootstrap4', plugins_url( '/vendor/datatables/media/js/dataTables.bootstrap4.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
+            wp_register_script( 'dataTables-responsive', plugins_url( '/vendor/datatables.net-responsive/js/dataTables.responsive.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
+            wp_register_script( 'responsive-bootstrap4', plugins_url( '/vendor/datatables.net-responsive-bs4/js/responsive.bootstrap4.min.js', STCR_PLUGIN_FILE ), array( 'jquery' ), false, true );
 
             // rergister styles
             wp_register_style( 'stcr-admin-style',  $stcr_admin_css );
@@ -578,7 +584,13 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
             if ( strpos( $hook, 'stcr' ) !== false ) {
 
                 // enqueue scripts
-                wp_enqueue_script('stcr-admin-js');
+                wp_enqueue_script( 'stcr-admin-js' );
+                wp_enqueue_script( 'fontawesome' );
+                wp_enqueue_script( 'bootstrap' );
+                wp_enqueue_script( 'webui-popover' );
+                wp_enqueue_script( 'datatables' );
+                wp_enqueue_script( 'datatables-bootstrap4' );
+                wp_enqueue_script( 'datatables-net-responsive-bs4' );
 
                 // enqueue styles
                 wp_enqueue_style( 'stcr-admin-style' );

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -839,7 +839,11 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
 
                     break;
                 case 'multicheck':
-                    update_option( 'subscribe_reloaded_' . $_option, wp_unslash( $_value ) );
+                    $final_value = array();
+                    foreach ( $_value as $value ) {
+                        $final_value[] = sanitize_text_field( $value );
+                    }
+                    update_option( 'subscribe_reloaded_' . $_option, $final_value );
 
                     break;
                 case 'select':

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -567,6 +567,12 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
 
             // rergister styles
             wp_register_style( 'stcr-admin-style',  $stcr_admin_css );
+            wp_register_style( 'fontawesome', plugins_url( '/vendor/Font-Awesome/web-fonts-with-css/css/fontawesome-all.min.css', STCR_PLUGIN_FILE ) );
+            wp_register_style( 'bootstrap', plugins_url( '/vendor/bootstrap/dist/css/bootstrap.min.css', STCR_PLUGIN_FILE ) );
+            wp_register_style( 'webui-popover', plugins_url( '/vendor/webui-popover/dist/jquery.webui-popover.min.css', STCR_PLUGIN_FILE ) );
+            wp_register_style( 'datatables', plugins_url( '/vendor/datatables/media/css/jquery.dataTables.min.css', STCR_PLUGIN_FILE ) );
+            wp_register_style( 'datatables-bootstrap4', plugins_url( '/vendor/datatables/media/css/dataTables.bootstrap4.min.css', STCR_PLUGIN_FILE ) );
+            wp_register_style( 'datatables-net-responsive-bs4', plugins_url( '/vendor/datatables.net-responsive-bs4/css/responsive.bootstrap4.min.css', STCR_PLUGIN_FILE ) );
 
             // check if we're on our pages
             if ( strpos( $hook, 'stcr' ) !== false ) {
@@ -575,7 +581,13 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
                 wp_enqueue_script('stcr-admin-js');
 
                 // enqueue styles
-                wp_enqueue_style('stcr-admin-style');
+                wp_enqueue_style( 'stcr-admin-style' );
+                wp_enqueue_style( 'fontawesome' );
+                wp_enqueue_style( 'bootstrap' );
+                wp_enqueue_style( 'webui-popover' );
+                wp_enqueue_style( 'datatables' );
+                wp_enqueue_style( 'datatables-bootstrap4' );
+                wp_enqueue_style( 'datatables-net-responsive-bs4' );
 
             }
 

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -998,16 +998,36 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
 		 */
 		public static function sanitize_options( $values ) {
 
+			// If the values is set to array, sanitize each of the values.
 			if ( is_array( $values ) ) {
 				$final_value = array();
 				foreach ( $values as $value ) {
 					$final_value[] = sanitize_text_field( $value );
 				}
-				$values = $final_value;
 
-				return $values;
+				return $final_value;
 			}
 
+			// If user have set the meta tag, then, sanitize that via wp_kses.
+			$matches = array();
+			preg_match( '/<meta/i', $values, $matches );
+			if ( $matches ) {
+				$final_value = wp_kses(
+					$values,
+					array(
+						'meta' => array(
+							'charset'    => array(),
+							'content'    => array(),
+							'http-equiv' => array(),
+							'name'       => array(),
+						),
+					)
+				);
+
+				return $final_value;
+			}
+
+			// Sanitize everything else with the HTML attributes available for posts.
 			return wp_kses_post( $values );
 
 		}

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -585,12 +585,12 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
 
                 // enqueue scripts
                 wp_enqueue_script( 'stcr-admin-js' );
-                wp_enqueue_script( 'fontawesome' );
                 wp_enqueue_script( 'bootstrap' );
                 wp_enqueue_script( 'webui-popover' );
-                wp_enqueue_script( 'datatables' );
-                wp_enqueue_script( 'datatables-bootstrap4' );
-                wp_enqueue_script( 'datatables-net-responsive-bs4' );
+                wp_enqueue_script( 'dataTables' );
+                wp_enqueue_script( 'dataTables-bootstrap4' );
+                wp_enqueue_script( 'dataTables-responsive' );
+                wp_enqueue_script( 'responsive-bootstrap4' );
 
                 // enqueue styles
                 wp_enqueue_style( 'stcr-admin-style' );

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -988,5 +988,28 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
 			return true;
 
 		}
+
+		/**
+		 * Sanitize the user input on plugin options save.
+		 *
+		 * @param string|array|mixed $values The plugin setting options.
+		 *
+		 * @return string|array|mixed The sanitized user data.
+		 */
+		public static function sanitize_options( $values ) {
+
+			if ( is_array( $values ) ) {
+				$final_value = array();
+				foreach ( $values as $value ) {
+					$final_value[] = sanitize_text_field( $value );
+				}
+				$values = $final_value;
+
+				return $values;
+			}
+
+			return wp_kses_post( $values );
+
+		}
 	}
 }


### PR DESCRIPTION
This PR includes:

* Remove the direct include of the CSS and JS library files in the plugin settings page
* Use the WordPress enqueue method to enqueue the CSS and JS library files in the plugin settings page
* Sanitize the missed user inputs for saving the plugin options data
* Use `wp_remote_get` instead of `file_get_contents` to get the required data from the third-party site