### PR TITLE
Fix Ask user to confirm email from admin

### DIFF
--- a/src/options/panel1-business-logic.php
+++ b/src/options/panel1-business-logic.php
@@ -47,7 +47,7 @@ switch ( $action ) {
         $wp_subscribe_reloaded->stcr->add_subscription( $post_id, $stcr_post_email, $status );
 
         if ( strpos( $status, 'C' ) !== false ) {
-            $wp_subscribe_reloaded->stcr->confirmation_email( $post_id, $email );
+            $wp_subscribe_reloaded->stcr->confirmation_email( $post_id, $stcr_post_email );
         }
 
         echo '<div class="updated"><p>' . esc_html__( 'Subscription added.', 'subscribe-to-comments-reloaded' ) . '</p></div>';


### PR DESCRIPTION
This PR includes:

* Fix - Email address when subscriber is added via admin through `Action` option, which is set as `Ask user to confirm`