### PR TITLE
Change Subscription Management Page Pagination Position

### DIFF
--- a/src/includes/css/stcr-style.css
+++ b/src/includes/css/stcr-style.css
@@ -2,3 +2,9 @@
   display: flex;
   flex-wrap: wrap;
 }
+.stcr-pagination-links .stcr-page-link {
+  display: block;
+  padding: 5px 15px;
+  margin-left: -1px;
+  border: 1px solid #eaeaea;
+}

--- a/src/includes/css/stcr-style.css
+++ b/src/includes/css/stcr-style.css
@@ -1,3 +1,4 @@
-.stcr-pagination-links .disabled {
-  cursor: auto;
+.stcr-pagination-links {
+  display: flex;
+  flex-wrap: wrap;
 }

--- a/src/includes/css/stcr-style.css
+++ b/src/includes/css/stcr-style.css
@@ -1,0 +1,3 @@
+.stcr-pagination-links .disabled {
+  cursor: auto;
+}

--- a/src/includes/css/stcr-style.css
+++ b/src/includes/css/stcr-style.css
@@ -8,3 +8,11 @@
   margin-left: -1px;
   border: 1px solid #eaeaea;
 }
+.stcr-pagination-links .stcr-page-link:first-child {
+  border-top-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+}
+.stcr-pagination-links .stcr-page-link:last-child {
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+}

--- a/src/includes/sass/stcr-style.scss
+++ b/src/includes/sass/stcr-style.scss
@@ -1,0 +1,6 @@
+.stcr-pagination-links {
+
+	.disabled {
+		cursor: auto;
+	}
+}

--- a/src/includes/sass/stcr-style.scss
+++ b/src/includes/sass/stcr-style.scss
@@ -1,6 +1,4 @@
 .stcr-pagination-links {
-
-	.disabled {
-		cursor: auto;
-	}
+	display: flex;
+	flex-wrap: wrap;
 }

--- a/src/includes/sass/stcr-style.scss
+++ b/src/includes/sass/stcr-style.scss
@@ -1,4 +1,11 @@
 .stcr-pagination-links {
 	display: flex;
 	flex-wrap: wrap;
+
+	.stcr-page-link {
+		display: block;
+		padding: 5px 15px;
+		margin-left: -1px;
+		border: 1px solid #eaeaea;
+	}
 }

--- a/src/includes/sass/stcr-style.scss
+++ b/src/includes/sass/stcr-style.scss
@@ -7,5 +7,15 @@
 		padding: 5px 15px;
 		margin-left: -1px;
 		border: 1px solid #eaeaea;
+
+		&:first-child {
+			border-top-left-radius: 5px;
+			border-bottom-left-radius: 5px;
+		}
+
+		&:last-child {
+			border-top-right-radius: 5px;
+			border-bottom-right-radius: 5px;
+		}
 	}
 }

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -124,10 +124,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         <?php
         // For first disable.
         if ( $disable_first ) {
-            echo '<span class="disabled" aria-hidden="true">&laquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&laquo;</span>';
         } else {
             printf(
-                '<a class="first-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-first-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
                 '&laquo;'
             );
@@ -135,10 +135,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For previous disable.
         if ( $disable_prev ) {
-            echo '<span class="disabled" aria-hidden="true">&lsaquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&lsaquo;</span>';
         } else {
             printf(
-                '<a class="prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
                 '&lsaquo;'
             );
@@ -149,21 +149,21 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
-                    '<span aria-current="page" class="page-numbers current">%s</span>',
+                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page">%s</span>',
                     esc_attr( number_format_i18n( $number ) )
                 );
                 $dots = true;
             } else {
                 if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
                     printf(
-                        '<a class="page-numbers" href="%s">%s</a>',
+                        '<a class="stcr-page-numbers" href="%s">%s</a>',
                         /** This filter is documented in wp-includes/general-template.php */
                         esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
                 } elseif ( $dots ) {
-                    echo '<span class="page-numbers dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                    echo '<span class="stcr-page-numbers stcr-dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
                     $dots = false;
                 }
             }
@@ -172,10 +172,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For next disable.
         if ( $disable_next ) {
-            echo '<span class="disabled" aria-hidden="true">&rsaquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&rsaquo;</span>';
         } else {
             printf(
-                '<a class="next-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-next-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
                 '&rsaquo;'
             );
@@ -183,10 +183,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For last disable.
         if ( $disable_last ) {
-            echo '<span class="disabled" aria-hidden="true">&raquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&raquo;</span>';
         } else {
             printf(
-                "<a class='last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
+                "<a class='stcr-last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
                 '&raquo;'
             );

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -145,7 +145,6 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         }
 
         // For page numbers.
-        echo '<span class="stcr-subscriptions-management-links">';
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
@@ -168,7 +167,6 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
                 }
             }
         }
-        echo '</span>';
 
         // For next disable.
         if ( $disable_next ) {

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -120,7 +120,7 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
     echo "</table>";
     ?>
 
-    <div class="stcr-pagination-links">
+    <p class="stcr-pagination-links">
         <?php
         // For first disable.
         if ( $disable_first ) {
@@ -190,7 +190,7 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
             );
         }
         ?>
-    </div>
+    </p>
 
     <?php
 	echo '<p id="subscribe-reloaded-select-all-p"><i class="fa fa-expand" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button  stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -124,10 +124,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         <?php
         // For first disable.
         if ( $disable_first ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&laquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
         } else {
             printf(
-                '<a class="stcr-first-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
                 '&laquo;'
             );
@@ -135,10 +135,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For previous disable.
         if ( $disable_prev ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&lsaquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
         } else {
             printf(
-                '<a class="stcr-prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
                 '&lsaquo;'
             );
@@ -149,21 +149,21 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
-                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page">%s</span>',
+                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
                     esc_attr( number_format_i18n( $number ) )
                 );
                 $dots = true;
             } else {
                 if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
                     printf(
-                        '<a class="stcr-page-numbers" href="%s">%s</a>',
+                        '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
                         /** This filter is documented in wp-includes/general-template.php */
                         esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
                 } elseif ( $dots ) {
-                    echo '<span class="stcr-page-numbers stcr-dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                    echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
                     $dots = false;
                 }
             }
@@ -172,10 +172,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For next disable.
         if ( $disable_next ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&rsaquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
         } else {
             printf(
-                '<a class="stcr-next-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
                 '&rsaquo;'
             );
@@ -183,10 +183,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For last disable.
         if ( $disable_last ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&raquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
         } else {
             printf(
-                "<a class='stcr-last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
+                "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
                 '&raquo;'
             );

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -118,33 +118,9 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 	}
         echo "</tbody>";
     echo "</table>";
+    ?>
 
-	echo '<p id="subscribe-reloaded-select-all-p"><i class="fa fa-expand" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button  stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';
-	echo '&nbsp;&nbsp;<i class="fa fa-compress" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button stcr-subs-select-none" href="#" onclick="stcrUncheckAll(event)">' . esc_html__( 'Invert selection', 'subscribe-to-comments-reloaded' ) . '</a></p>';
-	echo '<p id="subscribe-reloaded-action-p">' . esc_html__( 'Action:', 'subscribe-to-comments-reloaded' );
-	echo '&nbsp;&nbsp;<select name="sra">';
-		echo '<option value="">'. esc_html__( 'Choose your action', 'subscribe-to-comments-reloaded' ) .'</option>';
-		echo '<option value="delete">'. esc_html__( 'Unsubscribe', 'subscribe-to-comments-reloaded' ) .'</option>';
-		echo '<option value="suspend">'. esc_html__( 'Suspend', 'subscribe-to-comments-reloaded' ) .'</option>';
-		echo '<option value="force_y">'. esc_html__( 'All comments', 'subscribe-to-comments-reloaded' ) .'</option>';
-		echo '<option value="force_r">'. esc_html__( 'Replies to my comments', 'subscribe-to-comments-reloaded' ) .'</option>';
-//		echo '<option value="activate">'. esc_html__( 'Activate', 'subscribe-to-comments-reloaded' ) .'</option>';
-	echo '<select>';
-    echo '&nbsp;&nbsp;<input type="submit" class="subscribe-form-button" value="' . esc_html__( 'Update subscriptions', 'subscribe-to-comments-reloaded' ) . '" />
-          <input type="hidden" name="srp" value="' . intval( $post_ID ) . '"/></p>';
-	echo '<p id="subscribe-reloaded-update-p">
-            <a style="margin-right: 10px; text-decoration: none; box-shadow: unset;" href="'. esc_url( get_permalink( $post_ID ) ) .'"><i class="fa fa-arrow-circle-left fa-2x" aria-hidden="true" style="vertical-align: middle;"></i>&nbsp;'. esc_html__('Return to Post','subscribe-to-comments-reloaded').'</a>
-          </p>';
-
-
-} else {
-	echo '<p>' . esc_html__( 'No subscriptions match your search criteria.', 'subscribe-to-comments-reloaded' ) . '</p>';
-}
-?>
-		</fieldset>
-	</form>
-
-	<div class="stcr-pagination-links">
+    <div class="stcr-pagination-links">
         <?php
         // For first disable.
         if ( $disable_first ) {
@@ -217,6 +193,32 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         }
         ?>
     </div>
+
+    <?php
+	echo '<p id="subscribe-reloaded-select-all-p"><i class="fa fa-expand" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button  stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';
+	echo '&nbsp;&nbsp;<i class="fa fa-compress" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button stcr-subs-select-none" href="#" onclick="stcrUncheckAll(event)">' . esc_html__( 'Invert selection', 'subscribe-to-comments-reloaded' ) . '</a></p>';
+	echo '<p id="subscribe-reloaded-action-p">' . esc_html__( 'Action:', 'subscribe-to-comments-reloaded' );
+	echo '&nbsp;&nbsp;<select name="sra">';
+		echo '<option value="">'. esc_html__( 'Choose your action', 'subscribe-to-comments-reloaded' ) .'</option>';
+		echo '<option value="delete">'. esc_html__( 'Unsubscribe', 'subscribe-to-comments-reloaded' ) .'</option>';
+		echo '<option value="suspend">'. esc_html__( 'Suspend', 'subscribe-to-comments-reloaded' ) .'</option>';
+		echo '<option value="force_y">'. esc_html__( 'All comments', 'subscribe-to-comments-reloaded' ) .'</option>';
+		echo '<option value="force_r">'. esc_html__( 'Replies to my comments', 'subscribe-to-comments-reloaded' ) .'</option>';
+//		echo '<option value="activate">'. esc_html__( 'Activate', 'subscribe-to-comments-reloaded' ) .'</option>';
+	echo '<select>';
+    echo '&nbsp;&nbsp;<input type="submit" class="subscribe-form-button" value="' . esc_html__( 'Update subscriptions', 'subscribe-to-comments-reloaded' ) . '" />
+          <input type="hidden" name="srp" value="' . intval( $post_ID ) . '"/></p>';
+	echo '<p id="subscribe-reloaded-update-p">
+            <a style="margin-right: 10px; text-decoration: none; box-shadow: unset;" href="'. esc_url( get_permalink( $post_ID ) ) .'"><i class="fa fa-arrow-circle-left fa-2x" aria-hidden="true" style="vertical-align: middle;"></i>&nbsp;'. esc_html__('Return to Post','subscribe-to-comments-reloaded').'</a>
+          </p>';
+
+
+} else {
+	echo '<p>' . esc_html__( 'No subscriptions match your search criteria.', 'subscribe-to-comments-reloaded' ) . '</p>';
+}
+?>
+		</fieldset>
+	</form>
 
     <script type="text/javascript">
 

--- a/src/templates/author.php
+++ b/src/templates/author.php
@@ -120,77 +120,79 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
     echo "</table>";
     ?>
 
-    <p class="stcr-pagination-links">
-        <?php
-        // For first disable.
-        if ( $disable_first ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
-                '&laquo;'
-            );
-        }
-
-        // For previous disable.
-        if ( $disable_prev ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
-                '&lsaquo;'
-            );
-        }
-
-        // For page numbers.
-        for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
-            if ( $number === $subscriptions_pagenum ) {
-                printf(
-                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
-                    esc_attr( number_format_i18n( $number ) )
-                );
-                $dots = true;
+    <?php if ( $subscriptions_total_pages > 1 ) { ?>
+        <p class="stcr-pagination-links">
+            <?php
+            // For first disable.
+            if ( $disable_first ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
             } else {
-                if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
+                printf(
+                    '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
+                    '&laquo;'
+                );
+            }
+
+            // For previous disable.
+            if ( $disable_prev ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
+            } else {
+                printf(
+                    '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
+                    '&lsaquo;'
+                );
+            }
+
+            // For page numbers.
+            for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
+                if ( $number === $subscriptions_pagenum ) {
                     printf(
-                        '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
-                        /** This filter is documented in wp-includes/general-template.php */
-                        esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
+                        '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
-                } elseif ( $dots ) {
-                    echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
-                    $dots = false;
+                } else {
+                    if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
+                        printf(
+                            '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
+                            /** This filter is documented in wp-includes/general-template.php */
+                            esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
+                            esc_attr( number_format_i18n( $number ) )
+                        );
+                        $dots = true;
+                    } elseif ( $dots ) {
+                        echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                        $dots = false;
+                    }
                 }
             }
-        }
 
-        // For next disable.
-        if ( $disable_next ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
-                '&rsaquo;'
-            );
-        }
+            // For next disable.
+            if ( $disable_next ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
+            } else {
+                printf(
+                    '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
+                    '&rsaquo;'
+                );
+            }
 
-        // For last disable.
-        if ( $disable_last ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
-        } else {
-            printf(
-                "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
-                '&raquo;'
-            );
-        }
-        ?>
-    </p>
+            // For last disable.
+            if ( $disable_last ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
+            } else {
+                printf(
+                    "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
+                    '&raquo;'
+                );
+            }
+            ?>
+        </p>
+    <?php } ?>
 
     <?php
 	echo '<p id="subscribe-reloaded-select-all-p"><i class="fa fa-expand" aria-hidden="true"></i>&nbsp;<a class="subscribe-reloaded-small-button  stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -138,77 +138,79 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
     echo "</table>";
     ?>
 
-    <p class="stcr-pagination-links">
-        <?php
-        // For first disable.
-        if ( $disable_first ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
-                '&laquo;'
-            );
-        }
-
-        // For previous disable.
-        if ( $disable_prev ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
-                '&lsaquo;'
-            );
-        }
-
-        // For page numbers.
-        for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
-            if ( $number === $subscriptions_pagenum ) {
-                printf(
-                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
-                    esc_attr( number_format_i18n( $number ) )
-                );
-                $dots = true;
+    <?php if ( $subscriptions_total_pages > 1 ) { ?>
+        <p class="stcr-pagination-links">
+            <?php
+            // For first disable.
+            if ( $disable_first ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
             } else {
-                if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
+                printf(
+                    '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
+                    '&laquo;'
+                );
+            }
+
+            // For previous disable.
+            if ( $disable_prev ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
+            } else {
+                printf(
+                    '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
+                    '&lsaquo;'
+                );
+            }
+
+            // For page numbers.
+            for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
+                if ( $number === $subscriptions_pagenum ) {
                     printf(
-                        '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
-                        /** This filter is documented in wp-includes/general-template.php */
-                        esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
+                        '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
-                } elseif ( $dots ) {
-                    echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
-                    $dots = false;
+                } else {
+                    if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
+                        printf(
+                            '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
+                            /** This filter is documented in wp-includes/general-template.php */
+                            esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
+                            esc_attr( number_format_i18n( $number ) )
+                        );
+                        $dots = true;
+                    } elseif ( $dots ) {
+                        echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                        $dots = false;
+                    }
                 }
             }
-        }
 
-        // For next disable.
-        if ( $disable_next ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
-        } else {
-            printf(
-                '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
-                '&rsaquo;'
-            );
-        }
+            // For next disable.
+            if ( $disable_next ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
+            } else {
+                printf(
+                    '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
+                    '&rsaquo;'
+                );
+            }
 
-        // For last disable.
-        if ( $disable_last ) {
-            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
-        } else {
-            printf(
-                "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
-                esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
-                '&raquo;'
-            );
-        }
-        ?>
-    </p>
+            // For last disable.
+            if ( $disable_last ) {
+                echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
+            } else {
+                printf(
+                    "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
+                    esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
+                    '&raquo;'
+                );
+            }
+            ?>
+        </p>
+    <?php } ?>
 
     <?php
 	echo '<p id="subscribe-reloaded-select-all-p">

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -163,7 +163,6 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         }
 
         // For page numbers.
-        echo '<span class="stcr-subscriptions-management-links">';
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
@@ -186,7 +185,6 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
                 }
             }
         }
-        echo '</span>';
 
         // For next disable.
         if ( $disable_next ) {

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -142,10 +142,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         <?php
         // For first disable.
         if ( $disable_first ) {
-            echo '<span class="disabled" aria-hidden="true">&laquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&laquo;</span>';
         } else {
             printf(
-                '<a class="first-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-first-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
                 '&laquo;'
             );
@@ -153,10 +153,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For previous disable.
         if ( $disable_prev ) {
-            echo '<span class="disabled" aria-hidden="true">&lsaquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&lsaquo;</span>';
         } else {
             printf(
-                '<a class="prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
                 '&lsaquo;'
             );
@@ -167,21 +167,21 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
-                    '<span aria-current="page" class="page-numbers current">%s</span>',
+                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page">%s</span>',
                     esc_attr( number_format_i18n( $number ) )
                 );
                 $dots = true;
             } else {
                 if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
                     printf(
-                        '<a class="page-numbers" href="%s">%s</a>',
+                        '<a class="stcr-page-numbers" href="%s">%s</a>',
                         /** This filter is documented in wp-includes/general-template.php */
                         esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
                 } elseif ( $dots ) {
-                    echo '<span class="page-numbers dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                    echo '<span class="stcr-page-numbers stcr-dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
                     $dots = false;
                 }
             }
@@ -190,10 +190,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For next disable.
         if ( $disable_next ) {
-            echo '<span class="disabled" aria-hidden="true">&rsaquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&rsaquo;</span>';
         } else {
             printf(
-                '<a class="next-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-next-page" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
                 '&rsaquo;'
             );
@@ -201,10 +201,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For last disable.
         if ( $disable_last ) {
-            echo '<span class="disabled" aria-hidden="true">&raquo;</span>';
+            echo '<span class="stcr-disabled" aria-hidden="true">&raquo;</span>';
         } else {
             printf(
-                "<a class='last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
+                "<a class='stcr-last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
                 '&raquo;'
             );

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -138,7 +138,7 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
     echo "</table>";
     ?>
 
-    <div class="stcr-pagination-links">
+    <p class="stcr-pagination-links">
         <?php
         // For first disable.
         if ( $disable_first ) {
@@ -208,7 +208,7 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
             );
         }
         ?>
-    </div>
+    </p>
 
     <?php
 	echo '<p id="subscribe-reloaded-select-all-p">

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -136,52 +136,7 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
     }
     echo "</tbody>";
     echo "</table>";
-
-	echo '<p id="subscribe-reloaded-select-all-p">
-               <i class="fa fa-expand" aria-hidden="true"></i>&nbsp;
-               <a class="subscribe-reloaded-small-button stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';
-	echo '&nbsp;&nbsp;<i class="fa fa-compress" aria-hidden="true"></i>&nbsp;
-                <a class="subscribe-reloaded-small-button stcr-subs-select-none" href="#" onclick="stcrUncheckAll(event)">' . esc_html__( 'Invert selection', 'subscribe-to-comments-reloaded' ) . '</a></p>';
-	echo '<p id="subscribe-reloaded-action-p">' . esc_html__( 'Action:', 'subscribe-to-comments-reloaded' );
-
-    $show_option_all = true;
-    $show_option_replies = true;
-
-    if ( get_option( 'subscribe_reloaded_enable_advanced_subscriptions', 'no' ) == 'no' ) {
-        if ( get_option( 'subscribe_reloaded_checked_by_default_value', '0' ) == '0' ) {
-            $show_option_replies = false;
-        } else {
-            $show_option_all = false;
-        }
-    }
-
-	echo '<select name="sra">';
-		echo '<option value="">'. esc_html__( 'Choose your action', 'subscribe-to-comments-reloaded' ) .'</option>';
-		echo '<option value="delete">'. esc_html__( 'Unsubscribe', 'subscribe-to-comments-reloaded' ) .'</option>';
-        echo '<option value="suspend">'. esc_html__( 'Suspend', 'subscribe-to-comments-reloaded' ) .'</option>';
-        if ( $show_option_all ) {
-            echo '<option value="force_y">'. esc_html__( 'All comments', 'subscribe-to-comments-reloaded' ) .'</option>';
-        }
-        if ( $show_option_replies ) {
-            echo '<option value="force_r">'. esc_html__( 'Replies to my comments', 'subscribe-to-comments-reloaded' ) .'</option>';
-        }
-	echo '<select>';
-
-    echo '&nbsp;&nbsp;<input type="submit" class="subscribe-form-button" value="' . esc_html__( 'Update subscriptions', 'subscribe-to-comments-reloaded' ) . '" />
-          <input type="hidden" name="srek" value="' . $wp_subscribe_reloaded->stcr->utils->get_subscriber_key( $email ) . '"></p>';
-
-    if ( isset( $post_permalink ) )
-    {
-        echo '<p id="subscribe-reloaded-update-p">
-            <a style="margin-right: 10px; text-decoration: none; box-shadow: unset;" href="'. esc_url( $post_permalink ) .'"><i class="fa fa-arrow-circle-left fa-2x" aria-hidden="true" style="vertical-align: middle;"></i>&nbsp; '. esc_html__('Return to Post','subscribe-to-comments-reloaded').'</a>
-          </p>';
-    }
-} else {
-	echo '<p>' . esc_html__( 'No subscriptions match your search criteria.', 'subscribe-to-comments-reloaded' ) . '</p>';
-}
-?>
-		</fieldset>
-	</form>
+    ?>
 
     <div class="stcr-pagination-links">
         <?php
@@ -256,6 +211,53 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         }
         ?>
     </div>
+
+    <?php
+	echo '<p id="subscribe-reloaded-select-all-p">
+               <i class="fa fa-expand" aria-hidden="true"></i>&nbsp;
+               <a class="subscribe-reloaded-small-button stcr-subs-select-all" href="#" onclick="stcrCheckAll(event)">' . esc_html__( 'Select all', 'subscribe-to-comments-reloaded' ) . '</a> ';
+	echo '&nbsp;&nbsp;<i class="fa fa-compress" aria-hidden="true"></i>&nbsp;
+                <a class="subscribe-reloaded-small-button stcr-subs-select-none" href="#" onclick="stcrUncheckAll(event)">' . esc_html__( 'Invert selection', 'subscribe-to-comments-reloaded' ) . '</a></p>';
+	echo '<p id="subscribe-reloaded-action-p">' . esc_html__( 'Action:', 'subscribe-to-comments-reloaded' );
+
+    $show_option_all = true;
+    $show_option_replies = true;
+
+    if ( get_option( 'subscribe_reloaded_enable_advanced_subscriptions', 'no' ) == 'no' ) {
+        if ( get_option( 'subscribe_reloaded_checked_by_default_value', '0' ) == '0' ) {
+            $show_option_replies = false;
+        } else {
+            $show_option_all = false;
+        }
+    }
+
+	echo '<select name="sra">';
+		echo '<option value="">'. esc_html__( 'Choose your action', 'subscribe-to-comments-reloaded' ) .'</option>';
+		echo '<option value="delete">'. esc_html__( 'Unsubscribe', 'subscribe-to-comments-reloaded' ) .'</option>';
+        echo '<option value="suspend">'. esc_html__( 'Suspend', 'subscribe-to-comments-reloaded' ) .'</option>';
+        if ( $show_option_all ) {
+            echo '<option value="force_y">'. esc_html__( 'All comments', 'subscribe-to-comments-reloaded' ) .'</option>';
+        }
+        if ( $show_option_replies ) {
+            echo '<option value="force_r">'. esc_html__( 'Replies to my comments', 'subscribe-to-comments-reloaded' ) .'</option>';
+        }
+	echo '<select>';
+
+    echo '&nbsp;&nbsp;<input type="submit" class="subscribe-form-button" value="' . esc_html__( 'Update subscriptions', 'subscribe-to-comments-reloaded' ) . '" />
+          <input type="hidden" name="srek" value="' . $wp_subscribe_reloaded->stcr->utils->get_subscriber_key( $email ) . '"></p>';
+
+    if ( isset( $post_permalink ) )
+    {
+        echo '<p id="subscribe-reloaded-update-p">
+            <a style="margin-right: 10px; text-decoration: none; box-shadow: unset;" href="'. esc_url( $post_permalink ) .'"><i class="fa fa-arrow-circle-left fa-2x" aria-hidden="true" style="vertical-align: middle;"></i>&nbsp; '. esc_html__('Return to Post','subscribe-to-comments-reloaded').'</a>
+          </p>';
+    }
+} else {
+	echo '<p>' . esc_html__( 'No subscriptions match your search criteria.', 'subscribe-to-comments-reloaded' ) . '</p>';
+}
+?>
+		</fieldset>
+	</form>
 
     <script type="text/javascript">
 

--- a/src/templates/user.php
+++ b/src/templates/user.php
@@ -142,10 +142,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         <?php
         // For first disable.
         if ( $disable_first ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&laquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&laquo;</span>';
         } else {
             printf(
-                '<a class="stcr-first-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-first-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( remove_query_arg( 'subscription_paged', $current_url ) ),
                 '&laquo;'
             );
@@ -153,10 +153,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For previous disable.
         if ( $disable_prev ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&lsaquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&lsaquo;</span>';
         } else {
             printf(
-                '<a class="stcr-prev-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-prev-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => max( 1, $subscriptions_pagenum - 1 ) ), $current_url ) ),
                 '&lsaquo;'
             );
@@ -167,21 +167,21 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
         for ( $number = 1; $number <= $subscriptions_total_pages; $number ++ ) {
             if ( $number === $subscriptions_pagenum ) {
                 printf(
-                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page">%s</span>',
+                    '<span aria-current="page" class="stcr-page-numbers stcr-current-page stcr-page-link">%s</span>',
                     esc_attr( number_format_i18n( $number ) )
                 );
                 $dots = true;
             } else {
                 if ( $number <= 1 || ( $subscriptions_pagenum && $number >= $subscriptions_pagenum - 2 && $number <= $subscriptions_pagenum + 2 ) || $number > $subscriptions_total_pages - 1 ) {
                     printf(
-                        '<a class="stcr-page-numbers" href="%s">%s</a>',
+                        '<a class="stcr-page-numbers stcr-page-link" href="%s">%s</a>',
                         /** This filter is documented in wp-includes/general-template.php */
                         esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $number ), $current_url ) ),
                         esc_attr( number_format_i18n( $number ) )
                     );
                     $dots = true;
                 } elseif ( $dots ) {
-                    echo '<span class="stcr-page-numbers stcr-dots">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
+                    echo '<span class="stcr-page-numbers stcr-dots stcr-page-link">' . __( '&hellip;', 'subscribe-to-comments-reloaded' ) . '</span>';
                     $dots = false;
                 }
             }
@@ -190,10 +190,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For next disable.
         if ( $disable_next ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&rsaquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&rsaquo;</span>';
         } else {
             printf(
-                '<a class="stcr-next-page" href="%s"><span aria-hidden="true">%s</span></a>',
+                '<a class="stcr-next-page stcr-page-link" href="%s"><span aria-hidden="true">%s</span></a>',
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => min( $subscriptions_total_pages, $subscriptions_pagenum + 1 ) ), $current_url ) ),
                 '&rsaquo;'
             );
@@ -201,10 +201,10 @@ if ( is_array( $subscriptions ) && ! empty( $subscriptions ) ) {
 
         // For last disable.
         if ( $disable_last ) {
-            echo '<span class="stcr-disabled" aria-hidden="true">&raquo;</span>';
+            echo '<span class="stcr-disabled stcr-page-link" aria-hidden="true">&raquo;</span>';
         } else {
             printf(
-                "<a class='stcr-last-page' href='%s'><span aria-hidden='true'>%s</span></a>",
+                "<a class='stcr-last-page stcr-page-link' href='%s'><span aria-hidden='true'>%s</span></a>",
                 esc_url( add_query_arg( array( 'post_permalink' => $post_permalink, 'subscription_paged' => $subscriptions_total_pages ), $current_url ) ),
                 '&raquo;'
             );

--- a/src/utils/stcr_utils.php
+++ b/src/utils/stcr_utils.php
@@ -650,6 +650,10 @@ if( ! class_exists('\\'.__NAMESPACE__.'\\stcr_utils') )
                 wp_enqueue_style('stcr-font-awesome');
             }
 
+            $stcr_style_css = plugins_url( '/includes/css/stcr-style.css', STCR_PLUGIN_FILE );
+            wp_register_style( 'stcr-style', $stcr_style_css );
+            wp_enqueue_style( 'stcr-style' );
+
             // google recaptcha
             if ( get_option( 'subscribe_reloaded_use_captcha', 'no' ) == 'yes' ) {
 


### PR DESCRIPTION
This PR includes:

* Add basic CSS for the subscription management page pagination
* Move the subscription management page pagination just below the table
* No need to display the subscription management page pagination if the total number of pages to be generated is only one