### PR TITLE
Mark captchas as failed if post arguments are missing

### DIFF
--- a/src/templates/request-management-link.php
+++ b/src/templates/request-management-link.php
@@ -45,6 +45,8 @@ if ( $use_captcha == 'yes' ) {
                     $valid_captcha = false;
                 }
             }
+        } else {
+            $valid_captcha = false;
         }
     } elseif ( 'v3' == $recaptcha_version ) {
         if ( isset( $_POST['token'] ) ) {
@@ -66,6 +68,8 @@ if ( $use_captcha == 'yes' ) {
                     $valid_captcha = false;
                 }
             }
+        } else {
+            $valid_captcha = false;
         }
     } else {
         $valid_captcha = false;


### PR DESCRIPTION
Per the discussion in issue #745 It was noticed that some post requests were skipping the captcha checks. looking at the code this seams to be because the captcha passes if the post field is missing. This patch should resolve this.