### PR TITLE
Allow for nested shortcodes

### DIFF
--- a/src/templates/subscribe.php
+++ b/src/templates/subscribe.php
@@ -190,7 +190,7 @@ if ( ! empty( $email ) ) {
             $message = str_replace( '[post_title]', $target_post->post_title, $message );
         }
 
-        echo wp_kses( wpautop( $message ), wp_kses_allowed_html( 'post' ) );
+        echo do_shortcode(wp_kses( wpautop( $message ), wp_kses_allowed_html( 'post' ) ));
 
     }
 
@@ -214,7 +214,7 @@ if ( ! empty( $email ) ) {
     } else {
         $message = str_replace( '[post_title]', $target_post->post_title, $message );
     }
-    echo '<p>' . wp_kses( $message, wp_kses_allowed_html( 'post' ) ) . '</p>';
+    echo '<p>' . do_shortcode(wp_kses( $message, wp_kses_allowed_html( 'post' ) )) . '</p>';
 
     // output the form
 
@@ -292,7 +292,7 @@ if ( ! $valid_all ) {
     } else {
         $message = str_replace( '[post_title]', esc_html( $target_post->post_title ), $message );
     }
-    echo '<p>' . wp_kses( $message, wp_kses_allowed_html( 'post' ) ) . '</p>';
+    echo '<p>' . do_shortcode(wp_kses( $message, wp_kses_allowed_html( 'post' ) ) ). '</p>';
 
     ?>
     <?php $server_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : ''; ?>


### PR DESCRIPTION
We are using shortcodes in post titles, and before this fix, the shortcodes were just output as [shortcode]. With this fix, shortcodes in the `[post_title]` will be output correctly.

Before:
![image](https://github.com/stcr/subscribe-to-comments-reloaded/assets/1439765/03d781f9-47e2-4a38-b9fe-7054ad0f6dd8)

After:
![image](https://github.com/stcr/subscribe-to-comments-reloaded/assets/1439765/815f5c29-20d0-4d68-9c17-01c05b1b0853)

I'm not aware if there is a better way to allow for shortcodes, so please suggest any changes, as long as it fixes nested shortcodes! :D
